### PR TITLE
versions: bump to CoCo v0.11.0

### DIFF
--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 package versions
 
 var (
-	CocoVersion string = "v0.10.0"
+	CocoVersion string = "v0.11.0"
 	KbsVersion  string = "v0.10.1"
 	GitCommit   string = "unknown"
 )


### PR DESCRIPTION
Install CoCo v0.11.0 but kbs is kept on v0.10.1.